### PR TITLE
Feature: Add functionality for loading monopol statements dataset

### DIFF
--- a/00_datasets.qmd
+++ b/00_datasets.qmd
@@ -93,6 +93,39 @@ speeches = load_CB_speeches(2020)
 speeches.head()
 ```
 
+
+<!-- load_monopol_statements -->
+```{python}
+#| output: asis
+#| echo: false
+show_doc(load_monopol_statements)
+```
+
+This function downloads monetary policy statements for 26 EM central banks
+(Armenia, Brazil, Chile, Colombia, Czech Republic, Egypt, Georgia, Hungary,
+Israel, India, Kazakhstan, Malaysia, Mongolia, Mexico, Nigeria, Pakistan, Peru,
+Philippines, Poland, Romania, Russia, South Africa, South Korea, Thailand,
+Türkiye, Ukraine) as well as the Fed and the ECB (press-conference introductory statements).
+The dataset includes official English versions of statements for 1998-2023
+(starting date varies depending on data availability).
+If you use this data in your work, please cite the dataset, as follows:
+
+```
+@article{emcbcom,
+    author = {Tatiana Evdokimova and Piroska Nagy Mohácsi and Olga Ponomarenko and Elina Ribakova},
+    title = {Central banks and policy communication: How emerging markets have outperformed the Fed and ECB},
+    year = {2023},
+    institution = {Peterson Institute for International Economics}
+    url = {https://www.piie.com/publications/working-papers/central-banks-and-policy-communication-how-emerging-markets-have}
+}
+```
+
+```{python}
+# Load monopol statements for 2020
+speeches = load_monopol_statements(2020)
+speeches.head()
+```
+
 ## Simulated datasets
 
 :::{.callout-note}

--- a/gingado/datasets.py
+++ b/gingado/datasets.py
@@ -1,18 +1,22 @@
 from __future__ import annotations  # Allows forward annotations in Python < 3.10
 
-from io import BytesIO
 import os
 from pathlib import Path
-from zipfile import ZipFile
 
 import pandas as pd
-import requests
 import numpy as np
 from inspect import signature
 from sklearn.utils import check_random_state
 
-from gingado.internals import generate_timestamped_file_path, get_latest_timestamped_file_path
-from gingado.settings import CACHE_DIRECTORY, CB_SPEECHES_CSV_BASE_FILENAME, CB_SPEECHES_BASE_URL, CB_SPEECHES_ZIP_BASE_FILENAME
+from gingado.internals import download_csv, try_read_cached_csv, verify_cached_csv
+from gingado.settings import (
+    CACHE_DIRECTORY,
+    CB_SPEECHES_CSV_BASE_FILENAME,
+    CB_SPEECHES_BASE_URL,
+    CB_SPEECHES_ZIP_BASE_FILENAME,
+    MONOPOL_STATEMENTS_BASE_URL,
+    MONOPOL_STATEMENTS_CSV_BASE_FILENAME
+)
 
 __all__ = ['load_BarroLee_1994', 'make_causal_effect']
 
@@ -42,7 +46,10 @@ def load_BarroLee_1994(
 
 
 def load_CB_speeches(
-    year: str | int | list = 'all', cache: bool = True, timeout: float | None = 120, **kwargs
+    year: str | int | list = 'all',
+    cache: bool = True,
+    timeout: float | None = 120,
+    **kwargs
 ) -> pd.DataFrame:
     """Load Central Bankers speeches dataset from 
     Bank for International Settlements (2024). Central bank speeches, all years,
@@ -84,12 +91,7 @@ def load_CB_speeches(
         # Try to read the CSV file from cache
         cb_speeches_year_df: pd.DataFrame | None = None
         if cache:
-            try:
-                timestamped_file_path = get_latest_timestamped_file_path(cb_speeches_file_path)
-                cb_speeches_year_df = pd.read_csv(timestamped_file_path, **kwargs)
-            except FileNotFoundError:
-                # File is not in cache
-                cb_speeches_year_df = None
+            cb_speeches_year_df = try_read_cached_csv(cb_speeches_file_path, **kwargs)
 
         # Download the CSV file, if it could not be loaded from cache
         if cb_speeches_year_df is None:
@@ -99,31 +101,95 @@ def load_CB_speeches(
             )
             zip_url = CB_SPEECHES_BASE_URL + filename_no_extension + '.zip'
 
-            # Download the zip file, unzip it and parse the CSV file:
-            with requests.get(zip_url, timeout=timeout) as response:
-                zip_file_content = response.content
-                speeches_zip = ZipFile(BytesIO(zip_file_content))
-                with speeches_zip.open(filename_no_extension + '.csv', 'r') as speeches_zip_file:
-                    cb_speeches_year_df = pd.read_csv(speeches_zip_file, **kwargs)
-
-            # Write file to cache
-            timestamped_file_path = generate_timestamped_file_path(cb_speeches_file_path)
-            Path(cb_speeches_file_path).parent.mkdir(exist_ok=True)  # Ensure parent dir exists
-            cb_speeches_year_df.to_csv(timestamped_file_path, index=False)
+            # Download the zip file, unzip it and parse the CSV file
+            cb_speeches_year_df = download_csv(
+                zip_url,
+                zipped_filename=filename_no_extension + '.csv',
+                cache_filename=cb_speeches_file_path,
+                timeout=timeout,
+                **kwargs
+            )
 
         # Verify that the file in the cache is valid
-        try:
-            timestamped_file_path = get_latest_timestamped_file_path(cb_speeches_file_path)
-            verify_df = pd.read_csv(timestamped_file_path)
-            assert len(verify_df) > 0, f'CB speeches dataset at {timestamped_file_path} is empty.'
-        except Exception as ex:
-            raise RuntimeError('Verification error. See previous exception.') from ex
+        verify_cached_csv(cb_speeches_file_path)
 
         # Add dataframe for year to aggregated list of dataframes
         cb_speeches_dfs.append(cb_speeches_year_df)
 
     # Concat all dataframes into single dataframe and return
     return pd.concat(cb_speeches_dfs)
+
+
+def load_monopol_statements(
+    year: str | int | list = 'all',
+    cache: bool = True,
+    timeout: float | None = 120,
+    **kwargs
+) -> pd.DataFrame:
+    """Load monetary policy statements for 26 EM central banks.
+
+    Args:
+        year: Either 'all' to download all available central bank speeches or the year(s)
+            to download. Defaults to 'all'.
+        cache: If False, cached data will be ignored and the dataset will be downloaded again.
+            Defaults to True.
+        timeout: The timeout to for downloading each speeches file. Set to `None` to disable
+            timeout. Defaults to 120.
+        **kwargs. Additional keyword arguments which will be passed to pandas `read_csv` function.
+        
+    Returns:
+        A pandas DataFrame containing the dataset.
+
+    Usage:
+        >>> load_monopol_statements()
+
+        >>> load_monopol_statements('2020')
+
+        >>> load_monopol_statements([2020, 2021, 2022])
+    """
+    # Ensure year is list[str] for uniform handling
+    if not isinstance(year, list):
+        year = [str(year)]
+    year = [str(y) for y in year]
+
+    # Load data for each year
+    monopol_statements_dfs = []
+    for y in year:
+        # Get expected filename
+        if y == 'all':
+            filename_csv = MONOPOL_STATEMENTS_CSV_BASE_FILENAME + '_all' + '.csv'
+        else:
+            filename_csv = MONOPOL_STATEMENTS_CSV_BASE_FILENAME + f'_{y}' + '.csv'
+
+        # Get the file path of the CSV
+        monopol_statements_file_path = str(Path(CACHE_DIRECTORY) / filename_csv)
+
+        # Try to read the CSV file from cache
+        monopol_statements_year_df: pd.DataFrame | None = None
+        if cache:
+            monopol_statements_year_df = try_read_cached_csv(monopol_statements_file_path, **kwargs)
+
+        # Download the CSV file, if it could not be loaded from cache
+        if monopol_statements_year_df is None:
+            # Get CSV file URL
+            file_url = MONOPOL_STATEMENTS_BASE_URL + filename_csv
+
+            # Download CSV
+            monopol_statements_year_df = download_csv(
+                file_url,
+                cache_filename=monopol_statements_file_path,
+                timeout=timeout,
+                **kwargs
+            )
+
+        # Verify that the file in the cache is valid
+        verify_cached_csv(monopol_statements_file_path)
+
+        # Add dataframe for year to aggregated list of dataframes
+        monopol_statements_dfs.append(monopol_statements_year_df)
+
+    # Concat all dataframes into single dataframe and return
+    return pd.concat(monopol_statements_dfs)
 
 
 def make_causal_effect(

--- a/gingado/settings.py
+++ b/gingado/settings.py
@@ -15,3 +15,11 @@ CB_SPEECHES_ZIP_BASE_FILENAME = 'speeches'
 
 # Base path used for storing the speeches files on disk
 CB_SPEECHES_CSV_BASE_FILENAME = 'cb_speeches'
+
+## MONOPOL STATEMENTS SETTINGS
+
+# Base URL of CB speeches files (should end in a slash)
+MONOPOL_STATEMENTS_BASE_URL = 'https://raw.githubusercontent.com/bis-med-it/gingado/main/assets/'
+
+# Base path used for storing the speeches files on disk
+MONOPOL_STATEMENTS_CSV_BASE_FILENAME = 'monpol_statements'


### PR DESCRIPTION
This Pull Request adds a `load_monopol_statements` function for downloading the Monopol statements dataset which has been added to the repository at https://github.com/bis-med-it/gingado/tree/main/assets

Summary of changes:
- Add `load_monopol_statements` function and related documentation
- Extend internals module and refactor `load_CB_speeches` to increase reusability
