### PR TITLE
add future annotations to internals.py

### DIFF
--- a/gingado/internals.py
+++ b/gingado/internals.py
@@ -1,4 +1,6 @@
 """Functions intended for library internal use."""
+from __future__ import annotations  # Allows forward annotations in Python < 3.10
+
 import io
 import os
 from pathlib import Path


### PR DESCRIPTION
Adds future annotations import `internals.py` to avoid problem with function call signature in python versions < 3.10.